### PR TITLE
chaos: fix typo "print_"

### DIFF
--- a/benchmarks/chaos/typed/main.py
+++ b/benchmarks/chaos/typed/main.py
@@ -222,7 +222,7 @@ class Chaosgame(object):
             basepoint.y += -derivative.x / derivative.Mag() * (y - 0.5) * \
                            self.thickness
         else:
-            print_("r", end='')
+            print("r", end='')
         #bg: inlined
         ##self.truncate(basepoint)
         if basepoint.x >= self.maxx:


### PR DESCRIPTION
amazingly this was not a type error in retic